### PR TITLE
feat: add loan management endpoints (GET /api/loans, PATCH return)

### DIFF
--- a/src/Controller/LoanController.php
+++ b/src/Controller/LoanController.php
@@ -3,7 +3,9 @@
 namespace App\Controller;
 
 use App\Repository\BookRepository;
+use App\Repository\LoanRepository;
 use App\Services\LoanService;
+use App\Entity\Loan;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +18,7 @@ class LoanController extends AbstractController
     public function __construct(
         private readonly LoanService    $loanService,
         private readonly BookRepository $bookRepository,
+        private readonly LoanRepository $loanRepository,
     ) {}
 
     #[Route('', name: 'loan_create', methods: ['POST'])]
@@ -51,4 +54,66 @@ class LoanController extends AbstractController
             'status'     => $loan->getStatus(),
         ], 201);
     }
+
+    #[Route('/me', name: 'loan_my_list', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function myLoans(): JsonResponse
+    {
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+        $loans = $this->loanService->getLoansByUser($user);
+
+        return $this->json(array_map(fn($l) => $this->formatLoan($l), $loans));
+    }
+
+    #[Route('', name: 'loan_list_all', methods: ['GET'])]
+    #[IsGranted('ROLE_LIBRARIAN')]
+    public function listAll(Request $request): JsonResponse
+    {
+        $isLate = $request->query->has('is_late')
+            ? filter_var($request->query->get('is_late'), FILTER_VALIDATE_BOOLEAN)
+            : null;
+
+        $loans = $this->loanService->getAllActiveLoans($isLate);
+
+        return $this->json(array_map(fn($l) => $this->formatLoan($l), $loans));
+    }
+
+    #[Route('/{id}/return', name: 'loan_return', methods: ['PATCH'])]
+    #[IsGranted('ROLE_LIBRARIAN')]
+    public function returnLoan(int $id): JsonResponse
+    {
+        $loan = $this->loanRepository->find($id);
+
+        if (!$loan) {
+            return $this->json(['error' => 'Emprunt introuvable.'], 404);
+        }
+
+        try {
+            $loan = $this->loanService->returnLoan($loan);
+        } catch (\RuntimeException $e) {
+            return $this->json(['error' => $e->getMessage()], 409);
+        }
+
+        return $this->json($this->formatLoan($loan));
+    }
+
+    private function formatLoan(Loan $loan): array
+    {
+        return [
+            'id'         => $loan->getId(),
+            'bookId'     => $loan->getBook()->getId(),
+            'bookTitle'  => $loan->getBook()->getTitle(),
+            'userId'     => $loan->getUser()->getId(),
+            'loanDate'   => $loan->getLoanDate()->format('Y-m-d'),
+            'dueDate'    => $loan->getDueDate()->format('Y-m-d'),
+            'returnedAt' => $loan->getReturnedAt()?->format('Y-m-d'),
+            'status'     => $loan->getStatus(),
+            'isLate'     => $loan->isLate(),
+        ];
+    }
+
+
+
+
 }

--- a/src/Repository/LoanRepository.php
+++ b/src/Repository/LoanRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Loan;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\DBAL\ArrayParameterType;
 
 /**
  * @extends ServiceEntityRepository<Loan>
@@ -65,6 +66,22 @@ class LoanRepository extends ServiceEntityRepository
             ->orderBy('l.dueDate', 'ASC')
             ->getQuery()
             ->getResult();
+    }
+
+    public function findAllActive(?bool $isLate = null): array
+    {
+        $qb = $this->createQueryBuilder('l')
+            ->andWhere('l.status = :statusActive OR l.status = :statusOverdue')
+            ->setParameter('statusActive', Loan::STATUS_ACTIVE)
+            ->setParameter('statusOverdue', Loan::STATUS_OVERDUE)
+            ->orderBy('l.loanDate', 'DESC');
+
+        if ($isLate !== null) {
+            $qb->andWhere('l.isLate = :isLate')
+                ->setParameter('isLate', $isLate);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 
 }

--- a/src/Services/LoanService.php
+++ b/src/Services/LoanService.php
@@ -37,4 +37,32 @@ readonly class LoanService
 
         return $loan;
     }
+
+    public function returnLoan(Loan $loan): Loan
+    {
+        if ($loan->getStatus() === Loan::STATUS_RETURNED) {
+            throw new \RuntimeException('Cet emprunt a déjà été retourné.');
+        }
+
+        $loan->setReturnedAt(new \DateTimeImmutable());
+        $loan->setStatus(Loan::STATUS_RETURNED);
+
+        $book = $loan->getBook();
+        $book->setAvailableCopies($book->getAvailableCopies() + 1);
+
+        $this->em->flush();
+
+        return $loan;
+    }
+
+    public function getLoansByUser(User $user): array
+    {
+        return $this->loanRepository->findByUser($user);
+    }
+
+    public function getAllActiveLoans(?bool $isLate = null): array
+    {
+        return $this->loanRepository->findAllActive($isLate);
+    }
+
 }


### PR DESCRIPTION
 add loan management endpoints (GET /api/loans, PATCH return)

Routes ajoutées : 

- GET /api/loans/me => retourne la liste des emprunts de l'utilisateur connecté (tous statuts confondus), accessible ROLE_USER 
- GET /api/loans => retourne tous les emprunts actifs (ACTIVE + OVERDUE), accessible ROLE_LIBRARIAN uniquement
- GET /api/loans?is_late=true => même chose mais filtré sur les emprunts en retard uniquement 
- PATCH /api/loans/{id}/return => enregistre le retour d'un livre : passe le status à RETURNED, renseigne returnedAt, et remet le compteur availableCopies du livre à +1, accessible ROLE_LIBRARIAN