### PR TITLE
feat: add user profile endpoints (GET/PATCH /api/users/me)

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Controller;
+
+use App\Services\UserService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/users')]
+#[IsGranted('ROLE_USER')]
+class UserController extends AbstractController
+{
+    public function __construct(
+        private readonly UserService $userService,
+    ) {}
+
+    #[Route('/me', name: 'user_me', methods: ['GET'])]
+    public function me(): JsonResponse
+    {
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        return $this->json([
+            'id'        => $user->getId(),
+            'nom'       => $user->getLastName(),
+            'prenom'    => $user->getFirstName(),
+            'email'     => $user->getEmail(),
+            'phone'     => $user->getPhone(),
+            'roles'     => $user->getRoles(),
+            'createdAt' => $user->getCreatedAt()->format('Y-m-d'),
+        ]);
+    }
+
+    #[Route('/me', name: 'user_update_profile', methods: ['PATCH'])]
+    public function updateProfile(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        try {
+            $user = $this->userService->updateProfile($user, $data ?? []);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], 400);
+        }
+
+        return $this->json([
+            'id'     => $user->getId(),
+            'nom'    => $user->getLastName(),
+            'prenom' => $user->getFirstName(),
+            'email'  => $user->getEmail(),
+            'phone'  => $user->getPhone(),
+        ]);
+    }
+
+    #[Route('/me/password', name: 'user_update_password', methods: ['PATCH'])]
+    public function updatePassword(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+
+        /** @var \App\Entity\User $user */
+        $user = $this->getUser();
+
+        try {
+            $this->userService->updatePassword($user, $data ?? []);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], 400);
+        }
+
+        return $this->json(['message' => 'Mot de passe mis à jour.']);
+    }
+}

--- a/src/Services/UserService.php
+++ b/src/Services/UserService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+readonly class UserService
+{
+    public function __construct(
+        private UserRepository              $userRepository,
+        private UserPasswordHasherInterface $passwordHasher,
+        private EntityManagerInterface      $entityManager,
+    ) {}
+
+    public function updateProfile(User $user, array $data): User
+    {
+        if (empty($data['nom']) && empty($data['prenom']) && empty($data['email'])) {
+            throw new \InvalidArgumentException('Au moins un champ est requis.');
+        }
+
+        if (!empty($data['email'])) {
+            if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
+                throw new \InvalidArgumentException('Format email invalide.');
+            }
+
+            $existing = $this->userRepository->findByEmail($data['email']);
+            if ($existing && $existing->getId() !== $user->getId()) {
+                throw new \InvalidArgumentException('Cet email est déjà utilisé.');
+            }
+
+            $user->setEmail($data['email']);
+        }
+
+        if (!empty($data['nom'])) {
+            $user->setLastName($data['nom']);
+        }
+
+        if (!empty($data['prenom'])) {
+            $user->setFirstName($data['prenom']);
+        }
+
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    public function updatePassword(User $user, array $data): void
+    {
+        if (empty($data['ancien_mot_de_passe']) || empty($data['nouveau_mot_de_passe'])) {
+            throw new \InvalidArgumentException('Les deux champs mot de passe sont requis.');
+        }
+
+        if (!$this->passwordHasher->isPasswordValid($user, $data['ancien_mot_de_passe'])) {
+            throw new \InvalidArgumentException('Ancien mot de passe incorrect.');
+        }
+
+        if (strlen($data['nouveau_mot_de_passe']) < 8) {
+            throw new \InvalidArgumentException('Le nouveau mot de passe doit faire au moins 8 caractères.');
+        }
+
+        $user->setPassword($this->passwordHasher->hashPassword($user, $data['nouveau_mot_de_passe']));
+        $this->entityManager->flush();
+    }
+}


### PR DESCRIPTION
B4 — Endpoints profil utilisateur
                                                                                                                                                                                            
  3 routes ajoutées dans UserController, logique métier dans UserService.

  GET /api/users/me
  Retourne les infos du user connecté (id, nom, prénom, email, téléphone, rôles, date de création). Le mot de passe n'est jamais exposé.

  PATCH /api/users/me
  Modifie nom, prénom et/ou email du user connecté. Validations : format email, unicité email en base. Au moins un champ requis.

  PATCH /api/users/me/password
  Change le mot de passe. Requiert l'ancien mot de passe (vérifié via isPasswordValid), le nouveau doit faire minimum 8 caractères. Hashé en BCrypt avant persistance.

  Toutes les routes sont protégées par ROLE_USER via #[IsGranted] au niveau de la classe.