### PR TITLE
feat: add GET /api/stats/loans endpoint for librarian dashboard stats

### DIFF
--- a/src/Controller/StatsController.php
+++ b/src/Controller/StatsController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\LoanRepository;
+use App\Entity\Loan;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/stats')]
+class StatsController extends AbstractController
+{
+    public function __construct(
+        private readonly LoanRepository $loanRepository,
+    ) {}
+
+    #[Route('/loans', name: 'stats_loans', methods: ['GET'])]
+    #[IsGranted('ROLE_LIBRARIAN')]
+    public function loanStats(): JsonResponse
+    {
+        $overdueLoans = $this->loanRepository->findOverdueLoans();
+
+        return $this->json([
+            'activeLoans'  => $this->loanRepository->countActive(),
+            'lateLoans'    => $this->loanRepository->countLate(),
+            'overdueList'  => array_map(fn(Loan $l) => [
+                'id'        => $l->getId(),
+                'userId'    => $l->getUser()->getId(),
+                'userName'  => $l->getUser()->getFirstName() . ' ' . $l->getUser()->getLastName(),
+                'bookId'    => $l->getBook()->getId(),
+                'bookTitle' => $l->getBook()->getTitle(),
+                'dueDate'   => $l->getDueDate()->format('Y-m-d'),
+                'loanDate'  => $l->getLoanDate()->format('Y-m-d'),
+            ], $overdueLoans),
+        ]);
+    }
+}

--- a/src/Repository/LoanRepository.php
+++ b/src/Repository/LoanRepository.php
@@ -60,9 +60,10 @@ class LoanRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('l')
             ->andWhere('l.dueDate < :now')
-            ->andWhere('l.status = :status')
+            ->andWhere('l.status = :statusActive OR l.status = :statusOverdue')
+            ->setParameter('statusActive', Loan::STATUS_ACTIVE)
+            ->setParameter('statusOverdue', Loan::STATUS_OVERDUE)
             ->setParameter('now', new \DateTimeImmutable())
-            ->setParameter('status', Loan::STATUS_ACTIVE)
             ->orderBy('l.dueDate', 'ASC')
             ->getQuery()
             ->getResult();
@@ -82,6 +83,26 @@ class LoanRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->getResult();
+    }
+
+    public function countActive(): int
+    {
+        return(int) $this->createQueryBuilder('l')
+            ->select('COUNT(l.id)')
+            ->andWhere('l.status = :statusActive OR l.status = :statusOverdue')
+            ->setParameter('statusActive', Loan::STATUS_ACTIVE)
+            ->setParameter('statusOverdue', Loan::STATUS_OVERDUE)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countLate(): int
+    {
+        return (int) $this->createQueryBuilder('l')
+            ->select('COUNT(l.id)')
+            ->andWhere('l.isLate = true')
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
 }


### PR DESCRIPTION
Routes ajoutées 

  GET /api/stats/loans — accessible ROLE_LIBRARIAN / ROLE_ADMIN

Retourne un résumé des emprunts en cours :
  - activeLoans : nombre total d'emprunts non rendus (statuts ACTIVE + OVERDUE)
  - lateLoans : nombre d'emprunts en retard (isLate = true)
  - overdueList : liste détaillée des emprunts en retard avec id, userId, userName, bookId, bookTitle, dueDate, loanDate