### PR TITLE
Ajout reponse 403 dans la doc API 

### DIFF
--- a/src/Controller/ReviewController.php
+++ b/src/Controller/ReviewController.php
@@ -165,9 +165,6 @@ final class ReviewController extends AbstractController
     #[OA\Post(
         path: '/api/books/{id}/reviews',
         summary: 'Creer un avis sur un livre',
-        parameters: [
-            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
-        ],
         requestBody: new OA\RequestBody(
             required: true,
             content: new OA\JsonContent(
@@ -178,10 +175,14 @@ final class ReviewController extends AbstractController
                 ]
             )
         ),
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
         responses: [
             new OA\Response(response: 201, description: 'Avis cree'),
             new OA\Response(response: 400, description: 'Donnees invalides'),
             new OA\Response(response: 401, description: 'Non authentifie'),
+            new OA\Response(response: 403, description: 'Livre non emprunte par l utilisateur'),
             new OA\Response(response: 409, description: 'Avis deja existant pour ce livre'),
         ]
     )]


### PR DESCRIPTION
Ajout reponse 403 dans la doc API response: 403, description: 'Livre non emprunte par l utilisateur')